### PR TITLE
Fixing add

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ module.exports = function(glob, opts, cb) {
     return watcher.watched();
   };
   out.add = function(){
-    return watcher.add.call(watcher, arguments);
+    return watcher.add.apply(watcher, arguments); 
   };
   out.remove = function(){
     return watcher.remove();


### PR DESCRIPTION
Currently, add is not working at all: {0: "whatever"} will get passed as the sole argument to gaze.add.

The suggested fix changes that, and preserve the gaze.add signature, which I think was intended initially here.

Is this correct?

Thanks a lot.
