### PR TITLE
rollback gaze to 0.5.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Fractal <contact@wearefractal.com> (http://wearefractal.com/)",
   "main": "./index.js",
   "dependencies": {
-    "gaze": "^0.5.1"
+    "gaze": "~0.5.1"
   },
   "devDependencies": {
     "mocha": "^1.17.0",


### PR DESCRIPTION
According to de7b601e2b84b3a991e9b5fa35993230aab16d82 the version should be 0.5.x but version constraint in package.json `^0.5.1` still use the last version of gaze (`0.6.4`).
