### PR TITLE
Fix node 0.9 env on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,7 @@ language: node_js
 node_js:
   - "0.9"
   - "0.10"
+before_install:
+  - npm update -g npm
 after_script:
   - npm run coveralls


### PR DESCRIPTION
If you want Travis to keep testing on 0.9, this ought to fix it.