### PR TITLE
Update gaze version to 0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lib"
   ],
   "dependencies": {
-    "gaze": "^0.5.1"
+    "gaze": "^0.6.4"
   },
   "devDependencies": {
     "mocha": "^2.0.1",


### PR DESCRIPTION
Glob-watcher uses old version of gaze. The problem I've stumbled upon is that gaze uses old version of globule, which uses obsolete (1.0.1) version of lodash, which breaks under [babel-node](https://babeljs.io/).

Tests are ok.

Also please notice:
 - Travis build fails under node 0.9 and there is 'build: error' bar in README.
 - There is 'dependencies: up to date' bar despite the presence of new version of gaze.